### PR TITLE
Update Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ rust:
   - beta
   # check that it compiles on the latest stable compiler
   - stable
-os:
-  - linux
-  - osx
 cache:
   directories:
     - $HOME/.cargo
@@ -24,11 +21,7 @@ before_script:
   # load travis-cargo
   - |
       pip install 'travis-cargo<0.2' --user &&
-      if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-        export PATH=$HOME/.local/bin/:$PATH
-      else
-        export PATH=$HOME/Library/Python/2.7/bin:$PATH
-      fi
+      export PATH=$HOME/.local/bin/:$PATH
   # install rustfmt
   - |
       (cargo install rustfmt || true) &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,10 @@ before_script:
       else
         export PATH=$HOME/Library/Python/2.7/bin:$PATH
       fi
+  # install rustfmt
+  - |
+      (cargo install rustfmt || true) &&
+      export PATH=$PATH:$HOME/.cargo/bin
 install:
   # install libsodium
   - wget https://github.com/jedisct1/libsodium/releases/download/1.0.8/libsodium-1.0.8.tar.gz
@@ -39,6 +43,8 @@ install:
   - export LD_LIBRARY_PATH=$HOME/installed_libsodium/lib:$LD_LIBRARY_PATH
 # the main build
 script:
+  # run rustfmt
+  - cargo fmt -- --write-mode diff
   - |
       if [[ "$TRAVIS_RUST_VERSION" == nightly* ]]; then
         travis-cargo build -- --no-default-features


### PR DESCRIPTION
Enables rustfmt checking for all PRs, and disables OS X builds in the interest of faster PR turnaround.